### PR TITLE
Bugfix for cloning altera-container repo

### DIFF
--- a/build.py
+++ b/build.py
@@ -468,7 +468,7 @@ if pull is True:
         sp = utils.call_tool(call)
 # clone new
 else:
-    call = "git clone " + manifest_repo + " " + master_repo_path
+    call = "git clone " + manifest_repo + " \"" + master_repo_path + "\""
     sp = utils.call_tool(call)
 if sp != 0:
     utils.print_message(utils.logtype.ERROR,


### PR DESCRIPTION
Bugfix for cloning bsp-altera-container.git into directories containing spaces.
Added quotation marks around the destination directory.
