### PR TITLE
Change "python2" to "python" in first line

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
Users who are using python2 will no difference with this change, because "python" will still call python2.

For users who are using python3, this change will actually use python3 rather than trying to call python2 which may not even be installed. (Python2 is EOL.)