### PR TITLE
Added Python 3 support

### DIFF
--- a/archive/__init__.py
+++ b/archive/__init__.py
@@ -34,7 +34,7 @@ class Archive(object):
     def _archive_cls(file, filename=None):
         cls = None
         if not filename:
-            if isinstance(file, basestring):
+            if isinstance(file, str):
                 filename = file
             else:
                 try:
@@ -87,7 +87,7 @@ class BaseArchive(object):
 class TarArchive(BaseArchive):
 
     def __init__(self, file):
-        self._archive = tarfile.open(file) if isinstance(file, basestring) \
+        self._archive = tarfile.open(file) if isinstance(file, str) \
                 else tarfile.open(fileobj=file)
 
     def printdir(self, *args, **kwargs):

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/utils.py
+++ b/utils.py
@@ -127,7 +127,7 @@ class Utils:
             self.print_message(self.logtype.HEADER, call)
         try:
             proc = subprocess.Popen(call, stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT, shell=True)
+                                    stderr=subprocess.STDOUT, shell=True, universal_newlines=True)
             for line in proc.stdout:
                 if self.quiet_mode is False:
                     sys.stdout.write(line)
@@ -147,7 +147,7 @@ class Utils:
         call = "git rev-parse --short HEAD"
         with self.cd(root_path):
             try:
-                revision = subprocess.check_output(shlex.split(call))
+                revision = subprocess.check_output(shlex.split(call), universal_newlines=True)
             except:
                 revision = "unknown"
         return revision
@@ -261,7 +261,7 @@ class Utils:
     def check_tool(self, command, option, version_location, minimal_version):
         try:
             stdoutdata = subprocess.check_output([command, option],
-                                                 stderr=subprocess.PIPE)
+                                                 stderr=subprocess.PIPE, universal_newlines=True)
         except:
             return False
         local = \


### PR DESCRIPTION
Hi, I quickly made adjustments to support Python 3. Any objections? About the changes:

archive: backwards compatibility

 Force plain strings (str), which cannot represent characters
 outside of the Latin alphabet.

build: backwards compatibility

 Added the universal_newlines=True argument. The universal_newlines
 argument is equivalent to text and is provided for backwards
 compatibility. By default, file objects are opened in binary mode.

utils: backwards compatibility

 See build.